### PR TITLE
Added support for Python 3.5 and 3.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,9 +12,14 @@ environment:
     - CONFIG: win_c_compilervs2008cxx_compilervs2008python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015python3.5
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
     - CONFIG: win_c_compilervs2015cxx_compilervs2015python3.6
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015python3.7
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -1,0 +1,20 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -1,0 +1,20 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.5.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.5.yaml
@@ -1,0 +1,18 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2015
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'
+zip_keys:
+- - python
+  - c_compiler
+  - cxx_compiler

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -1,0 +1,18 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2015
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'
+zip_keys:
+- - python
+  - c_compiler
+  - cxx_compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,45 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
+  build_linux_python3.5:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_python3.5"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
   build_linux_python3.6:
     working_directory: ~/test
     machine: true
     environment:
       - CONFIG: "linux_python3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_python3.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_python3.7"
     steps:
       - checkout
       - run:
@@ -41,4 +75,6 @@ workflows:
   build_and_test:
     jobs:
       - build_linux_python2.7
+      - build_linux_python3.5
       - build_linux_python3.6
+      - build_linux_python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     - CONFIG=osx_python2.7
+    - CONFIG=osx_python3.5
     - CONFIG=osx_python3.6
+    - CONFIG=osx_python3.7
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ): 
-->

This closes #372

<!--
Please add any other relevant info below:
-->

Re-rendering deletes all additions. This should be run at least once to fix Python 3.5 builds with scikit-build (which are completely broken). Suggestion: after merge, the master branch including these modifications be branched into a `legacy` or `non-smithy` branch that can be re-applied to the master to address similar situations in the future (if they arise) where `scikit-build` is completely broken for a Python version not supported by `smithy`