### PR TITLE
fix: make should not be required on unix if ninja present

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ test:
     - cmake
     - cython
     - git
-    - make  # [unix]
     - mock
     - ninja
     - path.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - cmake
     - distro
-    - ninja
+    - make
     - packaging
     - python >=2.7
     - setuptools
@@ -39,16 +39,13 @@ test:
   requires:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake
     - cython
     - git
     - mock
-    - ninja
     - path.py
     - pytest
     - pytest-cov
     - pytest-mock
-    - pytest-runner
     - requests
     - setuptools
     - six


### PR DESCRIPTION
Trying to trigger https://github.com/conda-forge/gmatelastoplasticqpot-feedstock/pull/38 in tests.