### PR TITLE
chore: update to 0.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "0.16.7" %}
-{% set sha256 = "a9b9cc7479b71e6c8d434596dfade025253aae23adb22a9a2d85850fd51cecfd" %}
+{% set version = "0.17.0" %}
+{% set sha256 = "ceea0db1457748529579e0b068de96c7a47164b503159a1e582d94f8d5e19ca4" %}
 
 package:
   name: scikit-build
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/scikit-build/scikit-build-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/scikit-build/scikit_build-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -17,19 +17,18 @@ build:
 
 requirements:
   host:
-    - packaging
+    - hatch-fancy-pypi-readme
+    - hatch-vcs
+    - hatchling
     - pip
-    - python >=3.6
-    - setuptools
-    - setuptools_scm
-    - wheel
+    - python >=3.7
   run:
-    - cmake
     - distro
-    - make
     - packaging
-    - python >=3.6
+    - python >=3.7
     - setuptools
+    - tomli
+    - typing-extensions
     - wheel
 
 test:
@@ -43,8 +42,10 @@ test:
   requires:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake
     - cython
     - git
+    - make
     - path.py
     - pip
     - pytest


### PR DESCRIPTION
The SDist changed names to an `_` due to the switch to hatchling. Also removing cmake & make from required dependencies to fix #69. Downstream packages will need to add these dependencies if they are missing.